### PR TITLE
Bugfix: fail when modifying directory's times

### DIFF
--- a/test/test_setatime.py
+++ b/test/test_setatime.py
@@ -3,7 +3,7 @@ import time
 
 import pytest
 
-from win32_setfiletime import setatime
+from win32_setfiletime import setatime, setmtime, setctime
 
 
 def getatime(filepath):
@@ -132,3 +132,27 @@ def test_ctime_not_modified(tmp_path):
     time.sleep(0.1)
     setatime(filepath, 123456789)
     assert os.path.getctime(str(filepath)) == before
+
+
+def test_setatime_on_directory(tmp_path):
+    NEW_TIME = 100
+    dirpath = tmp_path / 'test_setatime_on_directory'
+    dirpath.mkdir()
+    setatime(dirpath, NEW_TIME)
+    assert os.path.getatime(str(dirpath)) == NEW_TIME
+
+
+def test_setmtime_on_directory(tmp_path):
+    NEW_TIME = 100
+    dirpath = tmp_path / 'test_setmtime_on_directory'
+    dirpath.mkdir()
+    setmtime(dirpath, NEW_TIME)
+    assert os.path.getmtime(str(dirpath)) == NEW_TIME
+
+
+def test_setctime_on_directory(tmp_path):
+    NEW_TIME = 100
+    dirpath = tmp_path / 'test_setctime_on_directory'
+    dirpath.mkdir()
+    setctime(dirpath, NEW_TIME)
+    assert os.path.getctime(str(dirpath)) == NEW_TIME

--- a/win32_setfiletime.py
+++ b/win32_setfiletime.py
@@ -52,7 +52,11 @@ def setctime(filepath, timestamp):
     mtime = wintypes.FILETIME(0xFFFFFFFF, 0xFFFFFFFF)
     ctime = wintypes.FILETIME(timestamp & 0xFFFFFFFF, timestamp >> 32)
 
-    handle = wintypes.HANDLE(CreateFileW(filepath, 256, 0, None, 3, 128, None))
+    flag = 128
+    if os.path.isdir(filepath):
+        flag |= 0x02000000  # for directory, you have to set flag FILE_FLAG_BACKUP_SEMANTICS when opening
+
+    handle = wintypes.HANDLE(CreateFileW(filepath, 256, 0, None, 3, flag, None))
     if handle.value == wintypes.HANDLE(-1).value:
         raise WinError()
 
@@ -78,7 +82,11 @@ def setmtime(filepath, timestamp):
     mtime = wintypes.FILETIME(timestamp & 0xFFFFFFFF, timestamp >> 32)
     ctime = wintypes.FILETIME(0xFFFFFFFF, 0xFFFFFFFF)
 
-    handle = wintypes.HANDLE(CreateFileW(filepath, 256, 0, None, 3, 128, None))
+    flag = 128
+    if os.path.isdir(filepath):
+        flag |= 0x02000000  # for directory, you have to set flag FILE_FLAG_BACKUP_SEMANTICS when opening
+
+    handle = wintypes.HANDLE(CreateFileW(filepath, 256, 0, None, 3, flag, None))
     if handle.value == wintypes.HANDLE(-1).value:
         raise WinError()
 
@@ -104,7 +112,11 @@ def setatime(filepath, timestamp):
     mtime = wintypes.FILETIME(0xFFFFFFFF, 0xFFFFFFFF)
     ctime = wintypes.FILETIME(0xFFFFFFFF, 0xFFFFFFFF)
 
-    handle = wintypes.HANDLE(CreateFileW(filepath, 256, 0, None, 3, 128, None))
+    flag = 128
+    if os.path.isdir(filepath):
+        flag |= 0x02000000  # for directory, you have to set flag FILE_FLAG_BACKUP_SEMANTICS when opening
+
+    handle = wintypes.HANDLE(CreateFileW(filepath, 256, 0, None, 3, flag, None))
     if handle.value == wintypes.HANDLE(-1).value:
         raise WinError()
 


### PR DESCRIPTION
Hello! This small utility is very useful. However I found a bug:

```python
Traceback (most recent call last):
  File "[obscured]", line 75, in [obscured]
    [obscured]
  File "[obscured]", line 31, in [obscured]
    [obscured]
  File "C:\Program Files\Python39\lib\site-packages\win32_setfiletime.py", line 57, in setctime
    raise WinError()
PermissionError: [WinError 5] Access is denied.
```

This occurs when I was trying to modify `mtime`, `ctime` or `atime` of a directory. I looked into the source code and found that the winapi `SetFileTime` which you are using is compatible with a directory, just need to add a flag `FILE_FLAG_BACKUP_SEMANTICS` when opening it with `CreateFileW`.

I added that flag when the given path points to a directory. I also addded some unit tests for them and they worked well on my system (Windows 10 x64 21H1 Education Edition, Python 3.9.6). I hope this is correct on your system as well.